### PR TITLE
feat: add all available scripts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,85 @@
 # Kickflip
 
 ## Project Overview
+
 Kickflip is an e-commerce platform focused on sneakers, allowing users to browse, select, and purchase from a wide variety of sneakers. Designed with usability and performance in mind, Kickflip aims to provide sneaker enthusiasts with a seamless shopping experience.
 
 ## Technology Stack
+
 - **Frontend**: React + TypeScript
 - **Bundling**: Vite
 - **Backend**: CommerceTools
 
 ## Available Scripts
+
 In the project directory, you can run several scripts:
 
-add additional scripts
+#### `npm run dev`
 
-#### `npm start`
-Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000) to view it in your browser. The page will reload if you make edits.
+Runs the app in the development mode using Vite. Open [http://localhost:3000](http://localhost:3000) to view it in your browser. The page will reload if you make edits.
 
 #### `npm run build`
+
 Builds the app for production to the `dist` folder. It correctly bundles React in production mode and optimizes the build for the best performance.
 
-#### `npm run test`
-Launches the test runner in the interactive watch mode.
+#### `npm run preview`
+
+Launches a preview server to preview the built app.
+
+#### `npm run lint`
+
+Lints the source files using ESLint for files with extensions .ts, .tsx, .js, and .jsx, reporting any unused disable directives.
+
+#### `npm run lint:fix`
+
+Fixes linting issues automatically where possible.
+
+#### `npm run ci:format`
+
+Checks if the source files adhere to the Prettier formatting.
+
+#### `npm run format`
+
+Formats the source files using Prettier.
+
+#### `npm run check`
+
+Runs linting and formatting checks.
+
+#### `npm run commit`
+
+Starts the Commitizen CLI for making commit messages.
+
+#### `npm run prepare`
+
+Executes Husky setup to initialize Git hooks.
+
+#### `npm test`
+
+Runs the test suite using Jest.
 
 ## Setting Up and Running Locally
+
 To set up and run Kickflip locally, follow these steps:
 
 1. **Clone the repository:**
    ```bash
    git clone https://github.com/makarovaiuliia/kickflip.git
    cd kickflip
+   ```
 2. **Install dependencies:**
    ```bash
    npm install
+   ```
 3. **Start the development server:**
    ```bash
    npm start
+   ```
 
 ## Contributors
 
-| Name            | Role           | GitHub                |
-| --------------  | -------------- | ---------------------------- |
-| Iuliia Makarova | Team Lead      | [makarovaiuliia](https://github.com/makarovaiuliia) |
-| Pavel Kuvshinov | Frontend       | [Pavel-Kuvshinov](https://github.com/Pavel-Kuvshinov) |
-| Svetlana Ilina  | Frontend       | [SvetaIlina](https://github.com/SvetaIlina) |
-
+| Name            | Role      | GitHub                                                |
+| --------------- | --------- | ----------------------------------------------------- |
+| Iuliia Makarova | Team Lead | [makarovaiuliia](https://github.com/makarovaiuliia)   |
+| Pavel Kuvshinov | Frontend  | [Pavel-Kuvshinov](https://github.com/Pavel-Kuvshinov) |
+| Svetlana Ilina  | Frontend  | [SvetaIlina](https://github.com/SvetaIlina)           |


### PR DESCRIPTION
## Overview
Clearly document all available scripts (e.g., for running ESLint, Prettier, and Jest  tests) and their usage in the README file.

**What has been done:**
- add scripts into package.json



**Issue(s) closed:**
-  `Closes RSS-ECOMM-1_19: document all available scripts`.

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update


