### PR TITLE
feat/RSS-ECOMM-3_12-13 Implement Enlarged Image Modal  whith Slider

### DIFF
--- a/kickFlip-project/package-lock.json
+++ b/kickFlip-project/package-lock.json
@@ -15,7 +15,8 @@
                 "react-hook-form": "^7.51.4",
                 "react-redux": "^9.1.2",
                 "react-router-dom": "^6.23.1",
-                "redux": "^5.0.1"
+                "redux": "^5.0.1",
+                "swiper": "^11.1.3"
             },
             "devDependencies": {
                 "@jest/globals": "^29.7.0",
@@ -10554,6 +10555,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/swiper": {
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.3.tgz",
+            "integrity": "sha512-80MSxonyTxrGcaWj9YgvvhD8OG0B9/9IVZP33vhIEvyWvmKjnQDBieO+29wKvMx285sAtvZyrWBdkxaw6+D3aw==",
+            "funding": [
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/swiperjs"
+                },
+                {
+                    "type": "open_collective",
+                    "url": "http://opencollective.com/swiper"
+                }
+            ],
+            "engines": {
+                "node": ">= 4.7.0"
             }
         },
         "node_modules/symbol-tree": {

--- a/kickFlip-project/package.json
+++ b/kickFlip-project/package.json
@@ -29,7 +29,8 @@
         "react-hook-form": "^7.51.4",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.23.1",
-        "redux": "^5.0.1"
+        "redux": "^5.0.1",
+        "swiper": "^11.1.3"
     },
     "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/kickFlip-project/src/components/modalSlider/modalSlider.css
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.css
@@ -28,9 +28,11 @@
         max-width: 100%;
         max-height: 90svh;
     }
+
     .content-wrapper {
         padding-top: 10px;
     }
+
     .slider-controler {
         padding-top: 5px;
     }

--- a/kickFlip-project/src/components/modalSlider/modalSlider.css
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.css
@@ -22,3 +22,16 @@
     font-size: 2rem;
     font-weight: 600;
 }
+
+@media (width <= 768px) {
+    .swiper-slide {
+        max-width: 100%;
+        max-height: 90svh;
+    }
+    .content-wrapper {
+        padding-top: 10px;
+    }
+    .slider-controler {
+        padding-top: 5px;
+    }
+}

--- a/kickFlip-project/src/components/modalSlider/modalSlider.css
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.css
@@ -1,9 +1,5 @@
-:root {
-    --container-width: 500px;
-}
-
 .swiper-slide {
-    max-width: var(--container-width);
+    max-width: 500px;
     position: relative;
     border-radius: 2rem;
     overflow: hidden;
@@ -14,22 +10,15 @@
     width: 100%;
 }
 
+.slider-controler {
+    display: flex;
+    padding-top: 15px;
+    justify-content: center;
+    gap: 70px;
+}
+
 .slider-arrow {
-    position: absolute;
-    bottom: 50%;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
     color: var(--electric-orange);
     font-size: 2rem;
     font-weight: 600;
-    z-index: 5;
-}
-
-.swiper-button-prev {
-    left: calc(51% - var(--container-width) / 2);
-}
-
-.swiper-button-next {
-    right: calc(51% - var(--container-width) / 2);
 }

--- a/kickFlip-project/src/components/modalSlider/modalSlider.css
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.css
@@ -1,0 +1,35 @@
+:root {
+    --container-width: 500px;
+}
+
+.swiper-slide {
+    max-width: var(--container-width);
+    position: relative;
+    border-radius: 2rem;
+    overflow: hidden;
+}
+
+.swiper-slide img {
+    display: block;
+    width: 100%;
+}
+
+.slider-arrow {
+    position: absolute;
+    bottom: 50%;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    color: var(--electric-orange);
+    font-size: 2rem;
+    font-weight: 600;
+    z-index: 5;
+}
+
+.swiper-button-prev {
+    left: calc(51% - var(--container-width) / 2);
+}
+
+.swiper-button-next {
+    right: calc(51% - var(--container-width) / 2);
+}

--- a/kickFlip-project/src/components/modalSlider/modalSlider.tsx
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.tsx
@@ -1,0 +1,46 @@
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/effect-coverflow';
+
+import './modalSlider.css';
+import { EffectCoverflow, Navigation } from 'swiper/modules';
+
+interface ModalSliderProps {
+    sliderImages: string[];
+}
+
+export default function ModalSlider({ sliderImages }: ModalSliderProps) {
+    return (
+        <Swiper
+            effect="coverflow"
+            grabCursor
+            centeredSlides
+            loop
+            slidesPerView="auto"
+            coverflowEffect={{
+                rotate: 0,
+                modifier: 2.5,
+            }}
+            navigation={{
+                nextEl: '.swiper-button-next',
+                prevEl: '.swiper-button-prev',
+            }}
+            modules={[EffectCoverflow, Navigation]}
+            className="swiper_container"
+        >
+            {sliderImages.map((img, index) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <SwiperSlide key={index}>
+                    <img src={img} alt="slide_image" />
+                </SwiperSlide>
+            ))}
+
+            <button className="swiper-button-prev slider-arrow" type="button">
+                &lt;
+            </button>
+            <button className="swiper-button-next slider-arrow" type="button">
+                &gt;
+            </button>
+        </Swiper>
+    );
+}

--- a/kickFlip-project/src/components/modalSlider/modalSlider.tsx
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.tsx
@@ -34,13 +34,14 @@ export default function ModalSlider({ sliderImages }: ModalSliderProps) {
                     <img src={img} alt="slide_image" />
                 </SwiperSlide>
             ))}
-
-            <button className="swiper-button-prev slider-arrow" type="button">
-                &lt;
-            </button>
-            <button className="swiper-button-next slider-arrow" type="button">
-                &gt;
-            </button>
+            <div className="slider-controler">
+                <button className="swiper-button-prev slider-arrow" type="button">
+                    &lt;
+                </button>
+                <button className="swiper-button-next slider-arrow" type="button">
+                    &gt;
+                </button>
+            </div>
         </Swiper>
     );
 }

--- a/kickFlip-project/src/components/modalSlider/modalSlider.tsx
+++ b/kickFlip-project/src/components/modalSlider/modalSlider.tsx
@@ -3,16 +3,27 @@ import 'swiper/css';
 import 'swiper/css/effect-coverflow';
 
 import './modalSlider.css';
-import { EffectCoverflow, Navigation } from 'swiper/modules';
+import { EffectCoverflow, Navigation, EffectCreative } from 'swiper/modules';
+import { useEffect, useState } from 'react';
 
 interface ModalSliderProps {
     sliderImages: string[];
 }
 
 export default function ModalSlider({ sliderImages }: ModalSliderProps) {
+    const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth < 768);
+        };
+
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
     return (
         <Swiper
-            effect="coverflow"
+            effect={`${isMobile ? 'creative' : 'coverflow'}`}
             grabCursor
             centeredSlides
             loop
@@ -21,11 +32,19 @@ export default function ModalSlider({ sliderImages }: ModalSliderProps) {
                 rotate: 0,
                 modifier: 2.5,
             }}
+            creativeEffect={{
+                prev: {
+                    translate: [0, 0, -400],
+                },
+                next: {
+                    translate: ['100%', 0, 0],
+                },
+            }}
             navigation={{
                 nextEl: '.swiper-button-next',
                 prevEl: '.swiper-button-prev',
             }}
-            modules={[EffectCoverflow, Navigation]}
+            modules={[EffectCoverflow, Navigation, EffectCreative]}
             className="swiper_container"
         >
             {sliderImages.map((img, index) => (

--- a/kickFlip-project/src/components/modalWindow/modalWindow.css
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.css
@@ -9,7 +9,7 @@
     top: 0;
     left: 0;
     z-index: 1;
-    background-color: rgba(67, 63, 63, 0.8);
+    background-color: rgb(67 63 63 / 80%);
     opacity: 0;
     transition: opacity 0.2s;
 }

--- a/kickFlip-project/src/components/modalWindow/modalWindow.css
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.css
@@ -1,0 +1,62 @@
+.modal-overlay {
+    position: fixed;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    transform: scale(0);
+    z-index: 1;
+    background-color: grey;
+}
+
+.content-wrapper {
+    position: relative;
+    min-width: 350px;
+    min-height: 60svh;
+    background-color: aliceblue;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.close-btn {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    font-size: 1.7rem;
+    color: red;
+}
+
+.modal-overlay.open {
+    transform: scaleY(0.01) scaleX(0);
+    animation: unfoldIn 1s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+}
+
+.modal-overlay.open .content-wrapper {
+    transform: scale(0);
+    animation: zoomIn 0.5s 0.8s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+}
+
+@keyframes unfoldIn {
+    0% {
+        transform: scaleY(0.005) scaleX(0);
+    }
+    50% {
+        transform: scaleY(0.005) scaleX(1);
+    }
+    100% {
+        transform: scaleY(1) scaleX(1);
+    }
+}
+
+@keyframes zoomIn {
+    0% {
+        transform: scale(0);
+    }
+    100% {
+        transform: scale(1);
+    }
+}

--- a/kickFlip-project/src/components/modalWindow/modalWindow.css
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.css
@@ -10,7 +10,7 @@
     left: 0;
     transform: scale(0);
     z-index: 1;
-    background-color: grey;
+    background-color: var(--border-gray);
 }
 
 .content-wrapper {
@@ -24,9 +24,9 @@
 
 .close-btn {
     position: absolute;
-    top: 5px;
-    right: calc(51% - var(--container-width) / 2);
-    font-size: 1.7rem;
+    top: 0;
+    right: 5px;
+    font-size: 2.7rem;
     color: var(--electric-orange);
     z-index: 2;
 }

--- a/kickFlip-project/src/components/modalWindow/modalWindow.css
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.css
@@ -1,4 +1,5 @@
 .modal-overlay {
+    padding: 10px;
     position: fixed;
     display: flex;
     justify-content: center;
@@ -16,7 +17,6 @@
     position: relative;
     min-width: 350px;
     min-height: 60svh;
-    background-color: aliceblue;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -25,9 +25,10 @@
 .close-btn {
     position: absolute;
     top: 5px;
-    right: 5px;
+    right: calc(51% - var(--container-width) / 2);
     font-size: 1.7rem;
-    color: red;
+    color: var(--electric-orange);
+    z-index: 2;
 }
 
 .modal-overlay.open {

--- a/kickFlip-project/src/components/modalWindow/modalWindow.css
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.css
@@ -61,3 +61,10 @@
         transform: scale(1);
     }
 }
+
+@media (width <= 768px) {
+    .close-btn {
+        top: 15px;
+        right: 12px;
+    }
+}

--- a/kickFlip-project/src/components/modalWindow/modalWindow.css
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.css
@@ -8,9 +8,10 @@
     width: 100%;
     top: 0;
     left: 0;
-    transform: scale(0);
     z-index: 1;
-    background-color: var(--border-gray);
+    background-color: rgba(67, 63, 63, 0.8);
+    opacity: 0;
+    transition: opacity 0.2s;
 }
 
 .content-wrapper {
@@ -32,34 +33,7 @@
 }
 
 .modal-overlay.open {
-    transform: scaleY(0.01) scaleX(0);
-    animation: unfoldIn 1s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
-}
-
-.modal-overlay.open .content-wrapper {
-    transform: scale(0);
-    animation: zoomIn 0.5s 0.8s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
-}
-
-@keyframes unfoldIn {
-    0% {
-        transform: scaleY(0.005) scaleX(0);
-    }
-    50% {
-        transform: scaleY(0.005) scaleX(1);
-    }
-    100% {
-        transform: scaleY(1) scaleX(1);
-    }
-}
-
-@keyframes zoomIn {
-    0% {
-        transform: scale(0);
-    }
-    100% {
-        transform: scale(1);
-    }
+    opacity: 1;
 }
 
 @media (width <= 768px) {

--- a/kickFlip-project/src/components/modalWindow/modalWindow.tsx
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import './modalWindow.css';
+
+interface ModalWindowProps {
+    content: string | JSX.Element;
+    closeModal: (isOpen: boolean) => void;
+    open: boolean;
+}
+
+export default function ModalWindow({ content, closeModal, open }: ModalWindowProps) {
+    const [isThisOpen, setIsThisOpen] = useState(false);
+    useEffect(() => setIsThisOpen(open), [open]);
+
+    return (
+        <div className={`modal-overlay ${isThisOpen ? 'open' : ''}`}>
+            <div className="content-wrapper">
+                <button
+                    className="close-btn"
+                    aria-label="Close"
+                    type="button"
+                    onClick={() => {
+                        closeModal(false);
+                    }}
+                >
+                    &times;
+                </button>
+                {content}
+            </div>
+        </div>
+    );
+}

--- a/kickFlip-project/src/components/modalWindow/modalWindow.tsx
+++ b/kickFlip-project/src/components/modalWindow/modalWindow.tsx
@@ -11,9 +11,40 @@ export default function ModalWindow({ content, closeModal, open }: ModalWindowPr
     const [isThisOpen, setIsThisOpen] = useState(false);
     useEffect(() => setIsThisOpen(open), [open]);
 
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                closeModal(false);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [closeModal]);
+
+    const handleOverlayClick = () => {
+        closeModal(false);
+    };
+
+    const handleContentClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+        e.stopPropagation();
+    };
+
     return (
-        <div className={`modal-overlay ${isThisOpen ? 'open' : ''}`}>
-            <div className="content-wrapper">
+        <div
+            className={`modal-overlay ${isThisOpen ? 'open' : ''}`}
+            onClick={handleOverlayClick}
+            onKeyDown={handleOverlayClick}
+            role="button"
+            tabIndex={0}
+        >
+            <div
+                className="content-wrapper"
+                onClick={handleContentClick}
+                onKeyDown={handleContentClick}
+                role="button"
+                tabIndex={0}
+            >
                 <button
                     className="close-btn"
                     aria-label="Close"

--- a/kickFlip-project/src/components/product/product.css
+++ b/kickFlip-project/src/components/product/product.css
@@ -203,11 +203,13 @@
         flex-direction: column;
         width: 45svw;
     }
+
     .side-wrapper {
         order: 1;
         flex-direction: row;
         justify-content: space-between;
     }
+
     .side-img {
         width: 70px;
         height: 70px;
@@ -219,6 +221,7 @@
     .details-container {
         max-width: 100%;
     }
+
     .side-wrapper {
         display: none;
     }

--- a/kickFlip-project/src/components/product/product.css
+++ b/kickFlip-project/src/components/product/product.css
@@ -12,6 +12,7 @@
     max-width: 600px;
     overflow: hidden;
     height: fit-content;
+    cursor: zoom-in;
 }
 
 .carousel-inner {

--- a/kickFlip-project/src/components/product/product.css
+++ b/kickFlip-project/src/components/product/product.css
@@ -197,3 +197,47 @@
 .cart-btn:hover {
     background: var(--deep-blue);
 }
+
+@media (width <= 1060px) {
+    .images-container {
+        flex-direction: column;
+        width: 45svw;
+    }
+    .side-wrapper {
+        order: 1;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+    .side-img {
+        width: 70px;
+        height: 70px;
+    }
+}
+
+@media (width <= 768px) {
+    .carousel-wrapper,
+    .details-container {
+        max-width: 100%;
+    }
+    .side-wrapper {
+        display: none;
+    }
+
+    .slider-btn {
+        bottom: 50%;
+    }
+
+    .slider-btn.prev {
+        left: 10px;
+    }
+
+    .size-container {
+        justify-content: center;
+    }
+}
+@media (width <= 500px) {
+    .slider-btn {
+        width: 20px;
+        height: 20px;
+    }
+}

--- a/kickFlip-project/src/components/product/product.tsx
+++ b/kickFlip-project/src/components/product/product.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { ProductResponse, ProductData, Price } from '@/types/types';
-import { getProductsSizes, processVariants } from '@/utils/utils';
+import { getProductsSizes, processVariants, setBodyoverflowStyle } from '@/utils/utils';
 import './product.css';
 
 import ImagesContainer from './productImages/imagesContainer';
 import DetailsContainer from './productDetails/productDetailsContainer';
 import ModalWindow from '../modalWindow/modalWindow';
+import ModalSlider from '../modalSlider/modalSlider';
 
 interface ProductProps {
     productData: ProductResponse;
@@ -23,6 +24,8 @@ export default function Product({ productData }: ProductProps) {
     const [images, setImages] = useState(Object.values(imagesData)[0]);
     const [isModalOpen, setIsModalOpen] = useState(false);
 
+    const modalContent = <ModalSlider sliderImages={images} />;
+    setBodyoverflowStyle(isModalOpen);
     return (
         <>
             <div className="product-wrapper">
@@ -43,7 +46,7 @@ export default function Product({ productData }: ProductProps) {
                     descrProps={{ description: productDescription }}
                 />
             </div>
-            {isModalOpen && <ModalWindow content="gjhgjkh" closeModal={setIsModalOpen} open={isModalOpen} />}
+            {isModalOpen && <ModalWindow content={modalContent} closeModal={setIsModalOpen} open={isModalOpen} />}
         </>
     );
 }

--- a/kickFlip-project/src/components/product/product.tsx
+++ b/kickFlip-project/src/components/product/product.tsx
@@ -5,6 +5,7 @@ import './product.css';
 
 import ImagesContainer from './productImages/imagesContainer';
 import DetailsContainer from './productDetails/productDetailsContainer';
+import ModalWindow from '../modalWindow/modalWindow';
 
 interface ProductProps {
     productData: ProductResponse;
@@ -20,20 +21,29 @@ export default function Product({ productData }: ProductProps) {
 
     const [activeIndex, setActiveIndex] = useState(0);
     const [images, setImages] = useState(Object.values(imagesData)[0]);
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
     return (
-        <div className="product-wrapper">
-            <ImagesContainer imagesSrc={images} activeIndex={activeIndex} setIndex={setActiveIndex} />
-            <DetailsContainer
-                infoProps={{ name: productName, priceData: productPrices }}
-                variantProps={{
-                    images: imagesData,
-                    setImages,
-                    currentImages: images,
-                }}
-                sizesProps={{ sizes }}
-                descrProps={{ description: productDescription }}
-            />
-        </div>
+        <>
+            <div className="product-wrapper">
+                <ImagesContainer
+                    imagesSrc={images}
+                    activeIndex={activeIndex}
+                    setIndex={setActiveIndex}
+                    openModal={setIsModalOpen}
+                />
+                <DetailsContainer
+                    infoProps={{ name: productName, priceData: productPrices }}
+                    variantProps={{
+                        images: imagesData,
+                        setImages,
+                        currentImages: images,
+                    }}
+                    sizesProps={{ sizes }}
+                    descrProps={{ description: productDescription }}
+                />
+            </div>
+            {isModalOpen && <ModalWindow content="gjhgjkh" closeModal={setIsModalOpen} open={isModalOpen} />}
+        </>
     );
 }

--- a/kickFlip-project/src/components/product/product.tsx
+++ b/kickFlip-project/src/components/product/product.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ProductResponse, ProductData, Price } from '@/types/types';
 import { getProductsSizes, processVariants, setBodyoverflowStyle } from '@/utils/utils';
 import './product.css';
@@ -23,18 +23,30 @@ export default function Product({ productData }: ProductProps) {
     const [activeIndex, setActiveIndex] = useState(0);
     const [images, setImages] = useState(Object.values(imagesData)[0]);
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth < 768);
+        };
+
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
 
     const modalContent = <ModalSlider sliderImages={images} />;
     setBodyoverflowStyle(isModalOpen);
     return (
         <>
             <div className="product-wrapper">
-                <ImagesContainer
-                    imagesSrc={images}
-                    activeIndex={activeIndex}
-                    setIndex={setActiveIndex}
-                    openModal={setIsModalOpen}
-                />
+                {!isMobile && (
+                    <ImagesContainer
+                        imagesSrc={images}
+                        activeIndex={activeIndex}
+                        setIndex={setActiveIndex}
+                        openModal={setIsModalOpen}
+                    />
+                )}
                 <DetailsContainer
                     infoProps={{ name: productName, priceData: productPrices }}
                     variantProps={{
@@ -44,6 +56,13 @@ export default function Product({ productData }: ProductProps) {
                     }}
                     sizesProps={{ sizes }}
                     descrProps={{ description: productDescription }}
+                    imgProps={{
+                        imagesSrc: images,
+                        activeIndex,
+                        setIndex: setActiveIndex,
+                        openModal: setIsModalOpen,
+                    }}
+                    isMobile={isMobile}
                 />
             </div>
             {isModalOpen && <ModalWindow content={modalContent} closeModal={setIsModalOpen} open={isModalOpen} />}

--- a/kickFlip-project/src/components/product/productDetails/productDetailsContainer.tsx
+++ b/kickFlip-project/src/components/product/productDetails/productDetailsContainer.tsx
@@ -3,11 +3,27 @@ import ProductDescription from './productDescr';
 import ProductInfo from './productInfo';
 import ProductSizes from './productSizes';
 import VariantsImages from './productVariantsImages';
+import MainImage from '../productImages/mainImage';
 
-export default function DetailsContainer({ infoProps, variantProps, sizesProps, descrProps }: DetailsContainerProps) {
+export default function DetailsContainer({
+    infoProps,
+    variantProps,
+    sizesProps,
+    descrProps,
+    imgProps,
+    isMobile,
+}: DetailsContainerProps) {
     return (
         <div className="details-container">
             <ProductInfo name={infoProps.name} priceData={infoProps.priceData} />
+            {isMobile && (
+                <MainImage
+                    imagesSrc={imgProps.imagesSrc}
+                    activeIndex={imgProps.activeIndex}
+                    setIndex={imgProps.setIndex}
+                    openModal={imgProps.openModal}
+                />
+            )}
             <VariantsImages
                 images={variantProps.images}
                 setImages={variantProps.setImages}

--- a/kickFlip-project/src/components/product/productImages/imagesContainer.tsx
+++ b/kickFlip-project/src/components/product/productImages/imagesContainer.tsx
@@ -3,11 +3,11 @@ import { ImgProps } from '@/types/componentsInterfaces';
 import MainImage from './mainImage';
 import SideImages from './sideImage';
 
-export default function ImagesContainer({ imagesSrc, setIndex, activeIndex }: ImgProps) {
+export default function ImagesContainer({ imagesSrc, setIndex, activeIndex, openModal }: ImgProps) {
     return (
         <div className="images-container">
             <SideImages imagesSrc={imagesSrc} activeIndex={activeIndex} setIndex={setIndex} />
-            <MainImage imagesSrc={imagesSrc} activeIndex={activeIndex} setIndex={setIndex} />
+            <MainImage imagesSrc={imagesSrc} activeIndex={activeIndex} setIndex={setIndex} openModal={openModal} />
         </div>
     );
 }

--- a/kickFlip-project/src/components/product/productImages/mainImage.tsx
+++ b/kickFlip-project/src/components/product/productImages/mainImage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ImgProps } from '@/types/componentsInterfaces';
 
-export default function MainImage({ imagesSrc, setIndex, activeIndex }: ImgProps) {
+export default function MainImage({ imagesSrc, setIndex, activeIndex, openModal }: ImgProps) {
     const [currentIndex, setCurrentIndex] = useState(activeIndex);
 
     useEffect(() => setIndex(currentIndex), [currentIndex, setIndex]);
@@ -15,12 +15,31 @@ export default function MainImage({ imagesSrc, setIndex, activeIndex }: ImgProps
         setCurrentIndex((prevIndex) => (prevIndex - 1 + imagesSrc.length) % imagesSrc.length);
     };
 
+    const handleOpen = () => {
+        if (openModal) {
+            openModal(true);
+        }
+    };
+
     return (
         <div className="carousel-wrapper">
-            <div className="carousel-inner" style={{ transform: `translateX(-${currentIndex * 100}%)` }}>
+            <div
+                className="carousel-inner"
+                style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+                onClick={handleOpen}
+                onKeyDown={handleOpen}
+                tabIndex={0}
+                role="button"
+                aria-label="show modal"
+            >
                 {imagesSrc.map((src, index) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <img key={index} src={src} alt={`Slide ${index}`} className="main-img" />
+                    <img
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={index}
+                        src={src}
+                        alt={`Slide ${index}`}
+                        className="main-img"
+                    />
                 ))}
             </div>
             <button className="slider-btn prev" onClick={handlePrev} aria-label="Previous image" type="button">

--- a/kickFlip-project/src/types/componentsInterfaces.ts
+++ b/kickFlip-project/src/types/componentsInterfaces.ts
@@ -4,6 +4,7 @@ export interface ImgProps {
     imagesSrc: string[];
     setIndex: (index: number) => void;
     activeIndex: number;
+    openModal?: (isOpen: boolean) => void;
 }
 
 export interface VariantImagesProps {

--- a/kickFlip-project/src/types/componentsInterfaces.ts
+++ b/kickFlip-project/src/types/componentsInterfaces.ts
@@ -35,4 +35,6 @@ export interface DetailsContainerProps {
     variantProps: VariantImagesProps;
     sizesProps: ProductSizesProps;
     descrProps: ProductDescriptionProps;
+    imgProps: ImgProps;
+    isMobile: boolean;
 }

--- a/kickFlip-project/src/utils/utils.ts
+++ b/kickFlip-project/src/utils/utils.ts
@@ -166,3 +166,13 @@ export const transformCategoryData = (responseData: ServerResponse<CategoriesRes
     });
     return categoryData;
 };
+
+export const setBodyoverflowStyle = (shoulBeHide: boolean) => {
+    let overflowStyle: string;
+    if (shoulBeHide) {
+        overflowStyle = 'hidden';
+    } else {
+        overflowStyle = '';
+    }
+    document.body.style.overflow = overflowStyle;
+};


### PR DESCRIPTION
## Overview
Clicking on a product image opens a larger version of the image in a modal window. the user can navigate through all product images from the commercetools API using the slider inside the modal window. 

**What has been done:**
- The product image triggers a modal to open when it is clicked.
- The modal displays an enlarged version of the product image.
- The enlarged image modal includes a slider that displays all product images fetched from the API.
- Users can navigate through the images using the slider controls.



**Issue(s) closed:**
#30 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Checklist:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

