### PR TITLE
Fix elements displaying

### DIFF
--- a/kickFlip-project/src/components/loader/loader.css
+++ b/kickFlip-project/src/components/loader/loader.css
@@ -1,3 +1,9 @@
+.loader-wrapper {
+    position: absolute;
+    top: 50%;
+    right: 50%;
+}
+
 .loader {
     width: 48px;
     height: 48px;

--- a/kickFlip-project/src/components/loader/loader.tsx
+++ b/kickFlip-project/src/components/loader/loader.tsx
@@ -2,8 +2,10 @@ import './loader.css';
 
 export default function Loader() {
     return (
-        <div className="loader">
-            <div className="loader-inner" />
+        <div className="loader-wrapper">
+            <div className="loader">
+                <div className="loader-inner" />
+            </div>
         </div>
     );
 }

--- a/kickFlip-project/src/pages/product/productPage.tsx
+++ b/kickFlip-project/src/pages/product/productPage.tsx
@@ -57,9 +57,11 @@ export default function ProductPage() {
 
     return (
         <div className="main-wrapper product-page-wrapper">
-            <BreadCrumbs crumbs={breadCrumbs} />
             {productData ? (
-                <Product productData={productData} />
+                <>
+                    <BreadCrumbs crumbs={breadCrumbs} />
+                    <Product productData={productData} />
+                </>
             ) : productError ? (
                 <div>{productError}</div>
             ) : (


### PR DESCRIPTION
## Overview
fixed displaying breadcrumbs only after loading product data on product page/ displaying loader in the middle of the page


## Type of Change
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
