### PR TITLE
fix: Correct error when navigation to non existing pages

### DIFF
--- a/kickFlip-project/src/components/app/app.tsx
+++ b/kickFlip-project/src/components/app/app.tsx
@@ -71,9 +71,9 @@ function App() {
         <Routes>
             <Route path="/" element={<BasicLayoutPage />}>
                 <Route index element={<HomePage />} />
-                <Route path="/:section" element={<ProductsPage />} />
-                <Route path="/:section/:category/:id/:slug" element={<ProductPage />} />
-                <Route path="/:section/:category" element={<ProductsPage />} />
+                <Route path="catalog/:section" element={<ProductsPage />} />
+                <Route path="catalog/:section/:category/:id/:slug" element={<ProductPage />} />
+                <Route path="catalog/:section/:category" element={<ProductsPage />} />
                 <Route path="about-us" element={<AboutUsPage />} />
                 <Route
                     path="profile/*"

--- a/kickFlip-project/src/components/card/card.tsx
+++ b/kickFlip-project/src/components/card/card.tsx
@@ -93,7 +93,7 @@ function Card({ productInfo, selectedColors }: CardProps): JSX.Element {
     return (
         <div className="card">
             <Link
-                to={`/${discountPrice ? 'outlet' : section}/${category}/${productInfo.id}/${slug['en-US']}`}
+                to={`/catalog/${discountPrice ? 'outlet' : section}/${category}/${productInfo.id}/${slug['en-US']}`}
                 className="image-link"
             >
                 <img src={images[activeImage][0]} alt="ProductImage" className="card_image" />

--- a/kickFlip-project/src/components/categorySection/categorySection.tsx
+++ b/kickFlip-project/src/components/categorySection/categorySection.tsx
@@ -9,7 +9,7 @@ export interface CategorySectionProps {
 function CategorySection({ category }: CategorySectionProps): JSX.Element {
     const { section } = useParams<{ section: string }>();
     return (
-        <Link to={`../${section}/${category.url}`} className="category_link">
+        <Link to={`/catalog/${section}/${category.url}`} className="category_link">
             <img src={category.imageUrl} className="category_image" alt={`category: ${category.sectionName}`} />
             <p className="category_title">{category.sectionName}</p>
         </Link>

--- a/kickFlip-project/src/components/footer/linkLists/linkListData.ts
+++ b/kickFlip-project/src/components/footer/linkLists/linkListData.ts
@@ -4,19 +4,16 @@ export interface LinkData {
 }
 
 export const catalog: LinkData[] = [
-    { title: 'Mens', link: '/products/men' },
-    { title: 'Women', link: '/products/women' },
-    { title: 'Kids', link: '/products/kids' },
+    { title: 'Mens', link: '/catalog/products/men' },
+    { title: 'Women', link: '/catalog/products/women' },
+    { title: 'Kids', link: '/catalog/products/kids' },
 ];
 
 export const discount: LinkData[] = [
-    { title: 'Outlet', link: '/outlet' },
-    { title: 'Outlet Men', link: '/outlet/men' },
-    { title: 'Outlet Women', link: '/outlet/women' },
-    { title: 'Outlet Kids', link: '/outlet/kids' },
+    { title: 'Outlet', link: '/catalog/outlet' },
+    { title: 'Outlet Men', link: '/catalog/outlet/men' },
+    { title: 'Outlet Women', link: '/catalog/outlet/women' },
+    { title: 'Outlet Kids', link: '/catalog/outlet/kids' },
 ];
 
-export const company: LinkData[] = [
-    { title: 'About Us', link: '/about-us' },
-    { title: 'About Shop', link: '/about-company' },
-];
+export const company: LinkData[] = [{ title: 'About Us', link: '/about-us' }];

--- a/kickFlip-project/src/components/header/header.tsx
+++ b/kickFlip-project/src/components/header/header.tsx
@@ -62,7 +62,7 @@ export default function Header() {
                                 className={({ isActive }) =>
                                     isActive ? 'categories-nav-link categories-nav-link-active' : 'categories-nav-link'
                                 }
-                                to="/products"
+                                to="/catalog/products"
                                 onClick={closeMenu}
                             >
                                 Catalog
@@ -71,7 +71,7 @@ export default function Header() {
                                 className={({ isActive }) =>
                                     isActive ? 'categories-nav-link categories-nav-link-active' : 'categories-nav-link'
                                 }
-                                to="/outlet"
+                                to="/catalog/outlet"
                                 onClick={closeMenu}
                             >
                                 Outlet

--- a/kickFlip-project/src/pages/notFoundPage/notFoundPage.tsx
+++ b/kickFlip-project/src/pages/notFoundPage/notFoundPage.tsx
@@ -4,7 +4,7 @@ import './notFoundPage.css';
 export default function NotFoundPage(): JSX.Element {
     return (
         <div className="main-wrapper notfound-wrapper">
-            <h1 className="notfound-title">Sorry, we can{" ' "}t fint this page</h1>
+            <h1 className="notfound-title">Sorry, we can’t find this page</h1>
             <p className="notfound-text">But we have many more things for you to explore.</p>
             <Link className="notfound-button" to="/">
                 back to homepage


### PR DESCRIPTION
## Overview
before when user went to non existing page he went to catalof because of this route: /:section, but not it looks like this /catalog/:section to prevent such errors

**What has been done:**
- change routing to correct errors

**Issue(s) closed:**
#83 